### PR TITLE
Docs: Update gcc and clang Compiler versions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,7 +41,7 @@ By default this will use the gcc-14 compiler included in the image, by setting `
 
 To be able to natively compile some prerequisites have to be installed:
 
-- gcc >= 13 and/or clang >= 17
+- gcc >= 14 and/or clang >= 20
 - cmake >= 3.25.0
 - ninja (or GNU make)
 - optional for python block support: python3

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![CI](https://github.com/gnuradio/gnuradio4/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/gnuradio/gnuradio4/actions/workflows/ci.yml)
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-18-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # GNU Radio 4.0

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ energy particle physics, astrophysics, radio astronomy and more!
 GNU Radio 4.0 uses modern C++ (C++23), and is tested for
 
 - CMake (>= 3.25),
-- GCC (>=13.3, better: >=14.2)
-- Clang (>=18, recommended), and
+- GCC (>=14, recommended: >=15)
+- Clang (>=20, recommended), and
 - Emscripten (5.0.2).
 
 **To build**:


### PR DESCRIPTION
This PR updates  the development documentation and the README to reflect the current versions that you can actually build and install GNU Radio 4 with.

## Motivation

Like myself and others, the first place we go to see how to build and compile the project is via the README, and then search for the DEVELOPMENT.md if one exists. This led me stray the first time I attempted to compile and install the project, and would like to provide some more recent documentation.

