### PR TITLE
QA: silence warning that future is discarded

### DIFF
--- a/core/test/qa_ManagedSubGraph.cpp
+++ b/core/test/qa_ManagedSubGraph.cpp
@@ -412,7 +412,7 @@ const boost::ut::suite GraphInspectYamlTests_ = [] {
             });
 
         scheduler.requestStop();
-        schedulerThreadHandle.get();
+        (void)schedulerThreadHandle.get();
         expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value());
         expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
     };
@@ -466,7 +466,7 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
             });
 
         scheduler.requestStop();
-        schedulerThreadHandle.get();
+        (void)schedulerThreadHandle.get();
         expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value());
         expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
     };
@@ -511,7 +511,7 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
             });
 
         scheduler.requestStop();
-        schedulerThreadHandle.get();
+        (void)schedulerThreadHandle.get();
         expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value());
         expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
     };


### PR DESCRIPTION
get() just called to make sure the value *can* be gotten

This leads to -Werror failures on F44 currently.
