### PR TITLE
ci: use apt-get instead of sudo apt in cpack workflow

### DIFF
--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -59,7 +59,9 @@ jobs:
         run: cmake --build build --target package
 
       - name: Verify package installation
-        run: sudo apt install ./build/*.deb ./build/*.ddeb -y
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: apt-get install -y ./build/*.deb ./build/*.ddeb
 
       - name: Upload packages
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Description

This PR fixes an issue where the `cpack` CI workflow fails with `sudo: not found`. 

Since the workflow container (`ghcr.io/gnuradio/ci:ubuntu-24.04-4.0`) runs as `root` by default, `sudo` is entirely redundant. Additionally, `apt` is intended for interactive CLI usage and is not recommended for CI scripts. 

### Changes Made:
- Removed `sudo` from the package verification step.
- Replaced `apt` with `apt-get`.
- Added the `DEBIAN_FRONTEND: noninteractive` environment variable to prevent the package manager from hanging on interactive prompts and to reduce progress-bar log spam.

Fixes #33

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
