### PR TITLE
activate script: make zsh-compatible

### DIFF
--- a/cmake/activate.sh.in
+++ b/cmake/activate.sh.in
@@ -12,6 +12,8 @@ export LD_LIBRARY_PATH="${_gr4_libdir}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 export DYLD_LIBRARY_PATH="${_gr4_libdir}${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}"
 export GNURADIO4_PLUGIN_DIRECTORIES="${_gr4_libdir}/gnuradio-4/plugins:${_gr4_libdir}${GNURADIO4_PLUGIN_DIRECTORIES:+:${GNURADIO4_PLUGIN_DIRECTORIES}}"
 
+[[ "${SHELLNAME}" = "zsh" ]] && setopt NULL_GLOB
+
 for _gr4_python_dir in "${_gr4_libdir}"/python*/site-packages "${_gr4_libdir}"/python*/dist-packages; do
   if [ -d "${_gr4_python_dir}" ]; then
     export PYTHONPATH="${_gr4_python_dir}${PYTHONPATH:+:${PYTHONPATH}}"


### PR DESCRIPTION
## Description

The activate.sh script fails on zsh, because there, specifying a `*` glob that matches nothing is an error in non-interactive mode.

## Affected area

dev tooling

## Component coordination

n/a

## Testing

personally tested; don't think this warrants doing a full CI workflow just to test a different shell

## Checklist

- [x] I understand and have tested this change.
- [x] I have read the [contribution guide](https://github.com/gnuradio/gnuradio4/blob/main/CONTRIBUTING.md).
- [x] Every commit has a [DCO sign-off](https://github.com/gnuradio/gnuradio4/blob/main/CONTRIBUTING.md#dco-sign-off).
- [x] I have linked related component changes, when applicable.
- [ ] I have updated relevant documentation.
- [x] I have added or updated tests where appropriate.
